### PR TITLE
Feature: single space

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,40 +11,40 @@ Contains:
 All functions, whether they should be implemented.
 
 #### append if schema identical
-* `append_if_schema_identical` - TODO. python.
+* [ ] `append_if_schema_identical` - python.
 #### dataframe_helpers
-* `column_to_list` - TODO. python. (this is just polars `select`, `collect`, `to_list`, much more convenient than spark).
-* `two_columns_to_dictionary` - TODO. python
+* [ ] `column_to_list` - python. (this is just polars `select`, `collect`, `to_list`, much more convenient than spark).
+* [ ] `two_columns_to_dictionary` - python
 * `to_list_of_dictionaries` - in polars. (check)
-* `show_output_to_df` - TODO. rename to something like `dataframe_output_to_df` python/rust.
+* [ ] `show_output_to_df` - rename to something like `dataframe_output_to_df` python/rust.
 * `create_df` - in polars native.
 
 #### dataframe validator
-* `validate_presence_of_columns` - TODO. python.
-* `validate_schema` - TODO. python.
-* `validate_absence_of_columns` - TODO. python.
+* [ ] `validate_presence_of_columns` - python.
+* [ ] `validate_schema` - python.
+* [ ] `validate_absence_of_columns` - python.
 
 #### Functions
-* `single_space` - TODO. rust.
-* `remove_all_whitespace` - TODO. rust.
-* `anti_trim` - TODO. rust.
-* `remove_non_word_characters` - TODO. rust.
+* [ ] `single_space` - rust.
+* [ ] `remove_all_whitespace` - rust.
+* [ ] `anti_trim` - rust.
+* [ ] `remove_non_word_characters` - rust.
 * `exists` - Propose not implement bc don't want to allow for an arbitrary python function as the callable. This requires inefficient map which will tank performance.
 * `forall` - see `exists`.
-* `multi_equals` - TODO. rust.
+* [ ] `multi_equals` - rust.
 * `week_start_date` - might be covered by `polars_xdt`.
 * `week_end_date` see `week_start_date`.
-* `approx_equal` - TODO. rust.
-* `array_choice` - TODO. rust. (interesting one, will be some way to do seed with a crate.)
+* [ ] `approx_equal` - rust.
+* [ ] `array_choice` - rust. (interesting one, will be some way to do seed with a crate.)
 * `business_days_between` - covered by `workday_count` in `polars_xdt`.
 * `uuid5` - can cover in `faux_lars`.
-* `is_falsy` - TODO. rust.
-* `is_truthy` - TODO. rust.
-* `is_false` - TODO. rust.
-* `is_true` - TODO. rust.
-* `is_null_or_blank` - TODO. rust.
+* [ ] `is_falsy` - rust.
+* [ ] `is_truthy` - rust.
+* [ ] `is_false` - rust.
+* [ ] `is_true` - rust.
+* [ ] `is_null_or_blank` - rust.
 * `is_not_in` - might be covered by native polars.
-* `null_between` - TODO. rust.
+* [ ] `null_between` - rust.
 
 ### Keyword Finder
 Propose skipping. Undocumented.
@@ -52,12 +52,12 @@ Wouldn't even make a very good log parser.
 
 ### math(s)
 * `rand_laplace` - generate random numbers with `Laplace(mu, beta)` - put into `faux_lars` if is worthwhile.
-* `div_or_else` - TODO. rust. Question - what about the other edge cases of `IEEE-754` - dividing by a minus number. Numerator is 0 etc. Can just decide/pass arg.
+* [ ] `div_or_else` - rust. Question - what about the other edge cases of `IEEE-754` - dividing by a minus number. Numerator is 0 etc. Can just decide/pass arg.
 
 ### Schema Helpers
-* `print_schema_as_code` - TODO. python.
-* `schema_from_csv` - TODO. python. (is this just scan_csv(path).schema ?)
-* `complex_fields` - TODO. python.
+* [ ] `print_schema_as_code` - python.
+* [ ] `schema_from_csv` - python. (is this just scan_csv(path).schema ?)
+* [ ] `complex_fields` - python.
 
 ### Split columns
 * `split_col` - `quinn` function expects only one delimiter, which may not be true... I prefer how `split` polars does it, where it returns an array column. Propose not implement, or add but with an index position argument.
@@ -65,9 +65,9 @@ Wouldn't even make a very good log parser.
 ### Transformations
 * `with_columns_renamed` - covered by `polars.DataFrame|LazyFrame.rename` in polars.
 * `with_some_columns_renamed` see `with_columns_renamed`.
-* `snake_case_col_names` TODO. python. Needs more robust tests than `quinn`.
+* [ ] `snake_case_col_names` python. Needs more robust tests than `quinn`.
 * `sort_columns` I think this is covered by polars sort?
-* `flatten_struct` TODO. python.
+* [ ] `flatten_struct` python.
 * `flatten_map` There is no `map` type in polars.
 * `flatten_dataframe` Could possibly not implement, I don't think this handles things like deeply nested structs; less robust than it sounds. Nested structs exist in pyspark but I'm not sure in polars...
 

--- a/harley/string_functions.py
+++ b/harley/string_functions.py
@@ -17,6 +17,7 @@ if parse_version(pl.__version__) < parse_version("0.20.16"):
 else:
     lib = Path(__file__).parent
 
+
 def single_space(expr: IntoExpr) -> IntoExpr:
     """
     Removes all whitespace from a string.

--- a/harley/string_functions.py
+++ b/harley/string_functions.py
@@ -5,10 +5,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-
 from harley.utils import parse_into_expr, register_plugin, parse_version
-from harley.dataframe_helper import column_to_list
-from harley.string_functions import single_space
 
 if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
@@ -20,4 +17,14 @@ if parse_version(pl.__version__) < parse_version("0.20.16"):
 else:
     lib = Path(__file__).parent
 
-__all__ = ["column_to_list", "single_space"]
+def single_space(expr: IntoExpr) -> IntoExpr:
+    """
+    Removes all whitespace from a string.
+    """
+    expr = parse_into_expr(expr)
+    return register_plugin(
+        args=[expr],
+        symbol="single_space",
+        is_elementwise=True,
+        lib=lib,
+    )

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -13,3 +13,28 @@ use std::fmt::Write;
 //     });
 //     Ok(out.into_series())
 // }
+
+#[polars_expr(output_type=String)]
+fn single_space(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca: &StringChunked = inputs[0].str()?;
+    let out: StringChunked = ca.apply_to_buffer(|value: &str, output: &mut String| {
+        if value == "" {return;}
+        let mut start_with_white_space = value.chars().next().unwrap().is_whitespace();
+        let mut to_add_space = false;
+        for c in value.chars() {
+            if c.is_whitespace() {
+                to_add_space = true;
+            } else {
+                if to_add_space {
+                    if !start_with_white_space {
+                        write!(output, " ").unwrap();
+                    }
+                    start_with_white_space = false;
+                    to_add_space = false;
+                }
+                write!(output, "{}", c).unwrap();
+            }
+        }
+    });
+    Ok(out.into_series())
+}

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -20,7 +20,7 @@ fn single_space(inputs: &[Series]) -> PolarsResult<Series> {
 
     let ca: &StringChunked = inputs[0].str()?;
     let out: StringChunked = ca.apply_to_buffer(|value: &str, output: &mut String| {
-        if let Some(_) = value.chars().next() {
+        if value.chars().next().is_some() {
             let n = value.chars().count();
             let mut first_non_space_index = n;
             let mut has_space = false;
@@ -35,8 +35,7 @@ fn single_space(inputs: &[Series]) -> PolarsResult<Series> {
                 } else {
                     if has_space {
                         if !first_space {
-                            output.push(' ');   
-                            // write!(output, " ").unwrap();
+                            output.push(' ');
                         }
                         has_space = false;
                     }
@@ -47,7 +46,7 @@ fn single_space(inputs: &[Series]) -> PolarsResult<Series> {
                 }
             }
             output.push_str(&value[first_non_space_index..n]);
-       }
+        }
     });
     Ok(out.into_series())
 }

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -23,3 +23,22 @@ def test_single_space(lazy: bool):
     if lazy:
         frame = frame.collect()
     assert_series_equal(frame["actual"], frame["expected"], check_names=False)
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_single_space_by_chars(lazy: bool):
+    string_data = [
+        ("  I\t\r\v\n go   ", "I go"),
+        ("    to", "to"),
+        ("school   ", "school"),
+        ("by bus", "by bus"),
+        (None, None),
+    ]
+    frame = pl.DataFrame([{"input": inp, "expected": exp} for inp, exp in string_data])
+    if lazy:
+        frame = frame.lazy()
+    frame = frame.with_columns(
+        actual = harley.single_space_by_chars("input")
+    )
+    if lazy:
+        frame = frame.collect()
+    assert_series_equal(frame["actual"], frame["expected"], check_names=False)

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -1,0 +1,25 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+import harley
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_single_space(lazy: bool):
+    string_data = [
+        ("  I  go   ", "I go"),
+        ("    to", "to"),
+        ("school   ", "school"),
+        ("by bus", "by bus"),
+        (None, None),
+    ]
+    frame = pl.DataFrame([{"input": inp, "expected": exp} for inp, exp in string_data])
+    if lazy:
+        frame = frame.lazy()
+    frame = frame.with_columns(
+        actual = harley.single_space("input")
+    )
+    if lazy:
+        frame = frame.collect()
+    assert_series_equal(frame["actual"], frame["expected"], check_names=False)

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -5,27 +5,9 @@ from polars.testing import assert_series_equal
 
 import harley
 
-@pytest.mark.parametrize("lazy", [True, False])
-def test_single_space(lazy: bool):
-    string_data = [
-        ("  I  go   ", "I go"),
-        ("    to", "to"),
-        ("school   ", "school"),
-        ("by bus", "by bus"),
-        (None, None),
-    ]
-    frame = pl.DataFrame([{"input": inp, "expected": exp} for inp, exp in string_data])
-    if lazy:
-        frame = frame.lazy()
-    frame = frame.with_columns(
-        actual = harley.single_space("input")
-    )
-    if lazy:
-        frame = frame.collect()
-    assert_series_equal(frame["actual"], frame["expected"], check_names=False)
 
 @pytest.mark.parametrize("lazy", [True, False])
-def test_single_space_by_chars(lazy: bool):
+def test_single_space(lazy: bool):
     string_data = [
         ("  I\t\r\v\n go   ", "I go"),
         ("    to", "to"),
@@ -36,9 +18,7 @@ def test_single_space_by_chars(lazy: bool):
     frame = pl.DataFrame([{"input": inp, "expected": exp} for inp, exp in string_data])
     if lazy:
         frame = frame.lazy()
-    frame = frame.with_columns(
-        actual = harley.single_space_by_chars("input")
-    )
+    frame = frame.with_columns(actual=harley.single_space("input"))
     if lazy:
         frame = frame.collect()
     assert_series_equal(frame["actual"], frame["expected"], check_names=False)


### PR DESCRIPTION
- implements the [single_space](https://mrpowers.github.io/quinn/reference/quinn/functions/#quinn.functions.single_space) function in rust directly without regex with tests in Python
- add corresponding test
- update README.md to show actual checklist instead of list with "TODO"

I've also benchmarked the function against just translating the function into polars, and the custom implementation is 50% faster!

```text
Dataframe length: 100000, time taken: 6.785
Average string length: 308.18258
    Min string length: 1
    Max string length: 893
Running 100 times...
Polars time taken: 16.239
Native time taken: 8.775
```

Also make sure you do use the `install-release` for benchmarking (or just `marturin develop --release`), otherwise it would be very slow -- I got >90s for "Native time" when just using `make install`.

<details>
<summary>Code for Benchmarking</summary>

```python
from harley import single_space
from timeit import timeit

import polars as pl
from string import ascii_letters
import random
import time
random.seed(0)

WHITESPACE_CHARACTERS = "\\r\\t\\n\\v "
def gen_segment() -> str:
    has_start = random.random() > 0.5
    has_end = random.random() > 0.5
    res = ""
    if has_start:
        res += "".join(random.choices(WHITESPACE_CHARACTERS, k=random.randint(1, 10)))
    n = random.randint(1, 10)
    for _ in range(n-1):
        res += "".join(random.choices(ascii_letters, k=random.randint(1, 100)))
        res += "".join(random.choices(WHITESPACE_CHARACTERS, k=random.randint(1, 10)))
    res += "".join(random.choices(ascii_letters, k=random.randint(1, 100)))
    if has_end:
        res += "".join(random.choices(WHITESPACE_CHARACTERS, k=random.randint(1, 10)))
    return res

DATAFRAME_LENGTH = 100000
start = time.perf_counter()
df = pl.DataFrame({"input": [gen_segment() for _ in range(DATAFRAME_LENGTH)]})
end = time.perf_counter()
print(f"Dataframe length: {len(df)}, time taken: {end-start:.3f}")

setup = """
from __main__ import df, pl, single_space
"""

string_lengths = df.select(pl.col('input').str.len_bytes())
print(f"Average string length: {string_lengths['input'].mean()}")
print(f"    Min string length: {string_lengths['input'].min()}")
print(f"    Max string length: {string_lengths['input'].max()}")

statement_polars = "df.select(native=pl.col('input').str.replace_all('\\s+', ' ').str.strip_chars())"
statement_native = "df.select(native=single_space('input'))"

TEST_TIMES = 100
print(f"Running {TEST_TIMES} times...")
polars_time_taken = timeit(statement_polars, setup=setup, number=TEST_TIMES)
print(f"Polars time taken: {polars_time_taken:.3f}")
native_time_taken = timeit(statement_native, setup=setup, number=TEST_TIMES)
print(f"Native time taken: {native_time_taken:.3f}")
```

</details>