### PR TITLE
Feature/two columns to dictionary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +59,15 @@ name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "atoi_simd"
@@ -112,6 +136,11 @@ name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -125,7 +154,25 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "windows-targets",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -148,6 +195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +220,18 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "equivalent"
@@ -209,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "harley"
 version = "0.1.0"
 dependencies = [
@@ -250,6 +324,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -301,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +442,26 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lz4"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -381,6 +507,24 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "target-features",
+]
+
+[[package]]
+name = "now"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -454,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "planus"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +622,11 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-error",
+ "polars-io",
+ "polars-lazy",
+ "polars-ops",
  "polars-parquet",
+ "polars-time",
  "polars-utils",
  "version_check",
 ]
@@ -495,6 +649,7 @@ dependencies = [
  "getrandom",
  "hashbrown",
  "itoa",
+ "lz4",
  "multiversion",
  "num-traits",
  "polars-arrow-format",
@@ -505,6 +660,7 @@ dependencies = [
  "streaming-iterator",
  "strength_reduce",
  "version_check",
+ "zstd",
 ]
 
 [[package]]
@@ -542,6 +698,7 @@ dependencies = [
  "ahash",
  "bitflags",
  "bytemuck",
+ "chrono",
  "either",
  "hashbrown",
  "indexmap",
@@ -555,6 +712,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
+ "regex",
  "smartstring",
  "thiserror",
  "version_check",
@@ -568,8 +726,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08888f58e61599b00f5ea0c2ccdc796b54b9859559cc0d4582733509451fa01a"
 dependencies = [
  "polars-arrow-format",
+ "regex",
  "simdutf8",
  "thiserror",
+]
+
+[[package]]
+name = "polars-expr"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4173591920fe56ad55af025f92eb0d08421ca85705c326a640c43856094e3484"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "once_cell",
+ "polars-arrow",
+ "polars-core",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "smartstring",
 ]
 
 [[package]]
@@ -590,6 +769,7 @@ checksum = "5842896aea46d975b425d63f156f412aed3cfde4c257b64fb1f43ceea288074e"
 dependencies = [
  "ahash",
  "bytes",
+ "chrono",
  "home",
  "memchr",
  "memmap2",
@@ -599,10 +779,35 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-error",
+ "polars-time",
  "polars-utils",
  "rayon",
  "regex",
  "smartstring",
+]
+
+[[package]]
+name = "polars-lazy"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e805ea2ebbc6b7749b0afb31b7fc5d32b42b57ba29b984549d43d3a16114c4a5"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "glob",
+ "once_cell",
+ "polars-arrow",
+ "polars-core",
+ "polars-expr",
+ "polars-io",
+ "polars-ops",
+ "polars-pipe",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "smartstring",
+ "version_check",
 ]
 
 [[package]]
@@ -650,6 +855,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-pipe"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a40ae1b3c74ee07e2d1f7cbf56c5d6e15969e45d9b6f0903bd2acaf783ba436"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "enum_dispatch",
+ "hashbrown",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-core",
+ "polars-expr",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-row",
+ "polars-utils",
+ "rayon",
+ "smartstring",
+ "uuid",
+ "version_check",
+]
+
+[[package]]
 name = "polars-plan"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +896,7 @@ dependencies = [
  "polars-core",
  "polars-io",
  "polars-ops",
+ "polars-time",
  "polars-utils",
  "rayon",
  "recursive",
@@ -686,6 +918,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-time"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ebec238d8b6200d9f0c3ce411c8441e950bd5a7df7806b8172d06c1d5a4b97"
+dependencies = [
+ "atoi",
+ "bytemuck",
+ "chrono",
+ "now",
+ "once_cell",
+ "polars-arrow",
+ "polars-core",
+ "polars-error",
+ "polars-ops",
+ "polars-utils",
+ "regex",
+ "smartstring",
+]
+
+[[package]]
 name = "polars-utils"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +954,7 @@ dependencies = [
  "rayon",
  "smartstring",
  "stacker",
+ "sysinfo",
  "version_check",
 ]
 
@@ -1121,6 +1374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "windows",
+]
+
+[[package]]
 name = "target-features"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1430,15 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"
@@ -1251,6 +1527,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1349,4 +1644,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.10+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type= ["cdylib"]
 pyo3 = { version = "0.21.2", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "0.14.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-polars = { version = "0.40.0", default-features = false }
+polars = { version = "0.40.0", default-features = false, features = ["dtype-date","dtype-datetime","dtype-duration","dtype-time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -1,0 +1,3 @@
+from .harley import two_columns_to_dictionary
+
+__all__ = ['two_columns_to_dictionary']

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ maturin
 ruff
 pytest
 mypy
+pyarrow

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,15 +1,48 @@
 #![allow(clippy::unused_unit)]
 use polars::prelude::*;
-use pyo3_polars::derive::polars_expr;
-use std::fmt::Write;
+use pyo3_polars::PyDataFrame;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyString,PyFloat};
+use pyo3::exceptions::PyValueError;
 
-// #[polars_expr(output_type=String)]
-// fn pig_latinnify(inputs: &[Series]) -> PolarsResult<Series> {
-//     let ca: &StringChunked = inputs[0].str()?;
-//     let out: StringChunked = ca.apply_to_buffer(|value: &str, output: &mut String| {
-//         if let Some(first_char) = value.chars().next() {
-//             write!(output, "{}{}ay", &value[1..], first_char).unwrap()
-//         }
-//     });
-//     Ok(out.into_series())
-// }
+#[pyfunction]
+pub fn two_columns_to_dictionary(py: Python, pydf: PyDataFrame, col1: &str, col2: &str) -> PyResult<Py<PyDict>> {
+    let df: DataFrame = pydf.into();
+    let series1 = df.column(col1).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{}", e)))?;
+    let series2 = df.column(col2).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{}", e)))?;
+
+    fn convert_series_value(py: Python, value: AnyValue) -> PyResult<PyObject> {
+        match value {
+            AnyValue::String(val) => Ok(PyString::new_bound(py, val).into_py(py)),
+            AnyValue::Int64(val) => Ok(val.into_py(py)),
+            AnyValue::UInt64(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::Float64(val) => Ok(PyFloat::new_bound(py, val).into_py(py)),
+            AnyValue::Null => Ok(py.None()), // Handle null values
+            AnyValue::Boolean(val) => Ok(val.into_py(py)),
+            AnyValue::Float32(val) => Ok(PyFloat::new_bound(py, val as f64).into_py(py)), // Convert Float32 to Float64
+            AnyValue::Int32(val) => Ok(val.into_py(py)),
+            AnyValue::UInt32(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::Int16(val) => Ok(val.into_py(py)),
+            AnyValue::UInt16(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::Int8(val) => Ok(val.into_py(py)),
+            AnyValue::UInt8(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::Date(val) => Ok(val.into_py(py)),
+            AnyValue::Datetime(val, _, _) => Ok(val.into_py(py)),
+            AnyValue::Duration(val, _) => Ok(val.into_py(py)),
+            AnyValue::Time(val) => Ok(val.into_py(py)),
+            _ => Err(PyErr::new::<PyValueError, _>("Unsupported data type")),
+        }
+    }
+
+    let py_dict = PyDict::new_bound(py);
+    let iter1 = series1.iter();
+    let iter2 = series2.iter();
+
+    for (val1, val2) in iter1.zip(iter2) {
+        let key = convert_series_value(py, val1)?;
+        let value = convert_series_value(py, val2)?;
+        py_dict.set_item(key, value)?;
+    }
+
+    Ok(py_dict.into())
+}

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -8,24 +8,24 @@ use pyo3::exceptions::PyValueError;
 #[pyfunction]
 pub fn two_columns_to_dictionary(py: Python, pydf: PyDataFrame, col1: &str, col2: &str) -> PyResult<Py<PyDict>> {
     let df: DataFrame = pydf.into();
-    let series1 = df.column(col1).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{}", e)))?;
-    let series2 = df.column(col2).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{}", e)))?;
+    let series1 = df.column(col1).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Error on selecting col1 {}", e)))?;
+    let series2 = df.column(col2).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Error on selecting col2 {}", e)))?;
 
     fn convert_series_value(py: Python, value: AnyValue) -> PyResult<PyObject> {
         match value {
             AnyValue::String(val) => Ok(PyString::new_bound(py, val).into_py(py)),
             AnyValue::Int64(val) => Ok(val.into_py(py)),
-            AnyValue::UInt64(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::UInt64(val) => Ok((val as i64).into_py(py)),
             AnyValue::Float64(val) => Ok(PyFloat::new_bound(py, val).into_py(py)),
-            AnyValue::Null => Ok(py.None()), // Handle null values
+            AnyValue::Null => Ok(py.None()),
             AnyValue::Boolean(val) => Ok(val.into_py(py)),
-            AnyValue::Float32(val) => Ok(PyFloat::new_bound(py, val as f64).into_py(py)), // Convert Float32 to Float64
+            AnyValue::Float32(val) => Ok(PyFloat::new_bound(py, val as f64).into_py(py)),
             AnyValue::Int32(val) => Ok(val.into_py(py)),
-            AnyValue::UInt32(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::UInt32(val) => Ok((val as i64).into_py(py)),
             AnyValue::Int16(val) => Ok(val.into_py(py)),
-            AnyValue::UInt16(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::UInt16(val) => Ok((val as i64).into_py(py)),
             AnyValue::Int8(val) => Ok(val.into_py(py)),
-            AnyValue::UInt8(val) => Ok((val as i64).into_py(py)), // Python's int can handle large integers
+            AnyValue::UInt8(val) => Ok((val as i64).into_py(py)),
             AnyValue::Date(val) => Ok(val.into_py(py)),
             AnyValue::Datetime(val, _, _) => Ok(val.into_py(py)),
             AnyValue::Duration(val, _) => Ok(val.into_py(py)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod expressions;
 mod utils;
+use expressions::two_columns_to_dictionary;
 
 #[cfg(target_os = "linux")]
 use jemallocator::Jemalloc;
@@ -10,10 +11,11 @@ static ALLOC: Jemalloc = Jemalloc;
 
 use pyo3::types::PyModule;
 use pyo3::Python;
-use pyo3::{pymodule, Bound, PyResult};
+use pyo3::{pymodule, Bound, PyResult, wrap_pyfunction};
 
 #[pymodule]
 fn harley(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(two_columns_to_dictionary, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
`two_columns_to_dictionary` function.

Slightly different from all the other rust functions - relies on standard py03 making a dictionary.
I think we should only implement this eagerly for the same reason - it's going to return a python object (just like how `Series().to_list()` only works lazily in polars I think).

More tests/type handling needed.
It might be a wee bit quicker to not check type on each value in the series, I'm going to see if I can figure out how to do that, still picking up py03 and pydict...