### PR TITLE
Feature/columns to snake case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
 name = "harley"
 version = "0.1.0"
 dependencies = [
+ "heck 0.5.0",
  "jemallocator",
  "polars",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ pyo3 = { version = "0.21.2", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "0.14.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 polars = { version = "0.40.0", default-features = false }
+heck = "0.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Wouldn't even make a very good log parser.
 ### Transformations
 * `with_columns_renamed` - covered by `polars.DataFrame|LazyFrame.rename` in polars.
 * `with_some_columns_renamed` see `with_columns_renamed`.
-* [ ] `snake_case_col_names` python. Needs more robust tests than `quinn`.
+* `snake_case_col_names` python. DONE. Needs more robust tests than `quinn`.
 * `sort_columns` I think this is covered by polars sort?
 * [ ] `flatten_struct` python.
 * `flatten_map` There is no `map` type in polars.

--- a/harley/__init__.py
+++ b/harley/__init__.py
@@ -8,6 +8,7 @@ import polars as pl
 
 from harley.utils import parse_into_expr, register_plugin, parse_version
 from harley.dataframe_helper import column_to_list
+from harley.transformations import snake_case_column_names
 
 if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
@@ -19,4 +20,4 @@ if parse_version(pl.__version__) < parse_version("0.20.16"):
 else:
     lib = Path(__file__).parent
 
-__all__ = ["column_to_list"]
+__all__ = ["column_to_list", "snake_case_column_names"]

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -1,7 +1,6 @@
 from harley.utils import PolarsFrame
 from .harley import columns_to_snake_case
 
-
 def snake_case_column_names(df: PolarsFrame) -> PolarsFrame:
     new_col_names = columns_to_snake_case(df.columns)
     return df.rename(new_col_names)

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -1,0 +1,7 @@
+from harley.utils import PolarsFrame
+from .harley import columns_to_snake_case
+
+
+def snake_case_column_names(df: PolarsFrame) -> PolarsFrame:
+    new_col_names = columns_to_snake_case(df.columns)
+    return df.rename(new_col_names)

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,15 +1,13 @@
 #![allow(clippy::unused_unit)]
-use polars::prelude::*;
-use pyo3_polars::derive::polars_expr;
-use std::fmt::Write;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use heck::ToSnakeCase;
 
-// #[polars_expr(output_type=String)]
-// fn pig_latinnify(inputs: &[Series]) -> PolarsResult<Series> {
-//     let ca: &StringChunked = inputs[0].str()?;
-//     let out: StringChunked = ca.apply_to_buffer(|value: &str, output: &mut String| {
-//         if let Some(first_char) = value.chars().next() {
-//             write!(output, "{}{}ay", &value[1..], first_char).unwrap()
-//         }
-//     });
-//     Ok(out.into_series())
-// }
+#[pyfunction]
+pub fn columns_to_snake_case(py:Python, columns: Vec<String>) -> PyResult<Py<PyDict>> {
+    let py_dict = PyDict::new_bound(py);
+    for col in columns.iter(){
+        py_dict.set_item(col, col.to_snake_case())?;
+    }
+    Ok(py_dict.into())
+}

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,4 +1,7 @@
 #![allow(clippy::unused_unit)]
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use std::fmt::Write;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use heck::ToSnakeCase;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod expressions;
 mod utils;
 
+use expressions::columns_to_snake_case;
+
 #[cfg(target_os = "linux")]
 use jemallocator::Jemalloc;
 
@@ -10,10 +12,11 @@ static ALLOC: Jemalloc = Jemalloc;
 
 use pyo3::types::PyModule;
 use pyo3::Python;
-use pyo3::{pymodule, Bound, PyResult};
+use pyo3::{pymodule, Bound, PyResult, wrap_pyfunction};
 
 #[pymodule]
 fn harley(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(columns_to_snake_case, m)?)?;
     Ok(())
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from polars import DataFrame, LazyFrame
+
+polars_frames = [DataFrame, LazyFrame]

--- a/tests/test_dataframe_validator.py
+++ b/tests/test_dataframe_validator.py
@@ -8,13 +8,10 @@ from harley.dataframe_validator import (
     DataFrameProhibitedColumnError,
 )
 import pytest
-from polars import DataFrame, LazyFrame
 from typing import OrderedDict, Union, Dict
-
-polars_frames = [DataFrame, LazyFrame]
+from tests.conftest import polars_frames
 
 age_name_data = {"age": [1, 2, 3], "name": ["jose", "li", "luisa"]}
-
 
 @pytest.mark.parametrize("frame_type", polars_frames)
 def test_validate_presence_of_columns_fail(frame_type: pl.DataType):

--- a/tests/test_snake_case_column_names.py
+++ b/tests/test_snake_case_column_names.py
@@ -1,0 +1,58 @@
+import pytest
+from harley.transformations import snake_case_column_names
+from polars import DataFrame, LazyFrame
+from typing import Union
+
+age_name_data = {"age": [1, 2, 3], "name": ["jose", "li", "luisa"]}
+
+columns = [
+    ["CamelCase", "camel_case"],
+    ["This is Human case.", "this_is_human_case"],
+    ["   This is preceding white space case.", "this_is_preceding_white_space_case"],
+    ["This is succeeding white space case   ", "this_is_succeeding_white_space_case"],
+    ["this.would.confuse.a.sql.query", "this_would_confuse_a_sql_query"],
+    ["MixedUP CamelCase, with some Spaces", "mixed_up_camel_case_with_some_spaces"],
+    [
+        "mixed_up_ snake_case with some _spaces",
+        "mixed_up_snake_case_with_some_spaces",
+    ],
+    ["kebab-case", "kebab_case"],
+    ["SHOUTY_SNAKE_CASE", "shouty_snake_case"],
+    ["snake_case", "snake_case"],
+    ["ABcDE", "a_bc_de"],
+    ["abcDEF", "abc_def"],
+    ["ABC123dEEf456FOO", "abc123d_e_ef456_foo"],
+    [
+        "this-contains_ ALLKinds OfWord_Boundaries",
+        "this_contains_all_kinds_of_word_boundaries",
+    ],
+    ["XΣXΣ baﬄe", "xσxς_baﬄe"],
+    ["XMLHttpRequest", "xml_http_request"],
+    ["FIELD_NAME11", "field_name11"],
+    ["99BOTTLES", "99bottles"],
+    ["FieldNamE11", "field_nam_e11"],
+    ["abc123def456", "abc123def456"],
+    ["abc123DEF456", "abc123_def456"],
+    ["abc123Def456", "abc123_def456"],
+    ["abc123DEf456", "abc123_d_ef456"],
+    ["ABC123def456", "abc123def456"],
+    ["ABC123DEF456", "abc123def456"],
+    ["ABC123Def456", "abc123_def456"],
+    ["ABC123DEf456", "abc123d_ef456"],
+]
+
+frame_column_combinations = []
+for columns in columns:
+    frame_column_combinations.append(tuple([DataFrame] + columns))
+    frame_column_combinations.append(tuple([LazyFrame] + columns))
+
+@pytest.mark.parametrize(
+    "frame_type, input_column, exp",
+    frame_column_combinations,
+)
+def test_snake_case_column_names(
+    frame_type: Union[LazyFrame, DataFrame], input_column: str, exp: str
+):
+    polars_frame = frame_type(data={input_column: range(10)})
+    res = snake_case_column_names(polars_frame).columns
+    assert res == [exp]


### PR DESCRIPTION
Add columns  -> snake case.
Tests: 
* Taken from`heck` tests
* quinn examples (focuses on `table.column` examples which would confuse a SQL query)
* leading/succeeding white space.

Maybe needs better error handling in the rust func? Just unwraps with result with `?` right now.