### PR TITLE
feature: two columns to dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ All functions, whether they should be implemented.
 #### append if schema identical
 * [ ] `append_if_schema_identical` - python.
 #### dataframe_helpers
-* [ ] `column_to_list` - python. (this is just polars `select`, `collect`, `to_list`, much more convenient than spark).
-* [ ] `two_columns_to_dictionary` - python
+* [*] `column_to_list` - python. (this is just polars `select`, `collect`, `to_list`, much more convenient than spark).
+* [*] `two_columns_to_dictionary` - python
 * `to_list_of_dictionaries` - in polars. (check)
 * [ ] `show_output_to_df` - rename to something like `dataframe_output_to_df` python/rust.
 * `create_df` - in polars native.
 
 #### dataframe validator
-* [ ] `validate_presence_of_columns` - python.
-* [ ] `validate_schema` - python.
-* [ ] `validate_absence_of_columns` - python.
+* [*] `validate_presence_of_columns` - python.
+* [*] `validate_schema` - python.
+* [*] `validate_absence_of_columns` - python.
 
 #### Functions
 * [ ] `single_space` - rust.

--- a/harley/dataframe_helper.py
+++ b/harley/dataframe_helper.py
@@ -1,6 +1,7 @@
 from harley.utils import PolarsFrame
-from polars import LazyFrame
-from typing import List
+from polars import LazyFrame, Array, Struct, DataFrame
+from polars import List as PolarsList
+from typing import List, Dict, Any
 
 
 def column_to_list(df: PolarsFrame, column: str) -> List:
@@ -8,3 +9,16 @@ def column_to_list(df: PolarsFrame, column: str) -> List:
         df = df.collect()
     series = df.select(column).to_series()
     return series.to_list()
+
+
+def two_columns_to_dictionary(
+    df: DataFrame, key_col_name: str, value_col_name: str
+) -> Dict[Any, Any]:
+    df = df.select(key_col_name, value_col_name)
+    if df.dtypes[0] in [Array, PolarsList, Struct]:
+        raise ValueError(
+            f"Column {key_col_name} is of type {df.dtypes[0]} will not return a hashable type.",
+            f"Therefore {key_col_name} cannot provide an acceptable key",
+        )
+    df = df.to_dicts()
+    return {row[key_col_name]: row[value_col_name] for row in df}

--- a/harley/dataframe_helper.py
+++ b/harley/dataframe_helper.py
@@ -1,5 +1,5 @@
 from harley.utils import PolarsFrame
-from polars import LazyFrame, Array, Struct, DataFrame
+from polars import LazyFrame, Object, Unknown, DataFrame
 from polars import List as PolarsList
 from typing import List, Dict, Any
 
@@ -15,10 +15,16 @@ def two_columns_to_dictionary(
     df: DataFrame, key_col_name: str, value_col_name: str
 ) -> Dict[Any, Any]:
     df = df.select(key_col_name, value_col_name)
-    if df.dtypes[0] in [Array, PolarsList, Struct]:
+    key_dtype =df.dtypes[0]
+    if key_dtype.is_nested():
         raise ValueError(
             f"Column {key_col_name} is of type {df.dtypes[0]} will not return a hashable type.",
             f"Therefore {key_col_name} cannot provide an acceptable key",
+        )
+    if key_dtype in [Object, Unknown]:
+        raise ValueError(
+            f"Column {key_col_name} is of type {df.dtypes[0]} and may not return a hashable type.",
+            f"Therefore {key_col_name} cannot provide an acceptable key.",
         )
     df = df.to_dicts()
     return {row[key_col_name]: row[value_col_name] for row in df}

--- a/harley/dataframe_helper.py
+++ b/harley/dataframe_helper.py
@@ -1,6 +1,6 @@
 from harley.utils import PolarsFrame
 from polars import LazyFrame, Object, Unknown, DataFrame
-from polars import List as PolarsList
+from polars import col
 from typing import List, Dict, Any
 
 
@@ -12,10 +12,13 @@ def column_to_list(df: PolarsFrame, column: str) -> List:
 
 
 def two_columns_to_dictionary(
-    df: DataFrame, key_col_name: str, value_col_name: str
+    df: DataFrame,
+    key_col_name: str,
+    value_col_name: str,
+    allow_duplicates_keys: bool = False,
 ) -> Dict[Any, Any]:
     df = df.select(key_col_name, value_col_name)
-    key_dtype =df.dtypes[0]
+    key_dtype = df.dtypes[0]
     if key_dtype.is_nested():
         raise ValueError(
             f"Column {key_col_name} is of type {df.dtypes[0]} will not return a hashable type.",
@@ -26,5 +29,16 @@ def two_columns_to_dictionary(
             f"Column {key_col_name} is of type {df.dtypes[0]} and may not return a hashable type.",
             f"Therefore {key_col_name} cannot provide an acceptable key.",
         )
+    if not allow_duplicates_keys:
+        if df.filter(col(key_col_name).is_duplicated()).height > 0:
+            raise ValueError(
+                "Duplicate records found in key column.",
+                "Duplicate keys will be overwritten and de-duplicated unpredicatbly.",
+                "To allow duplicate keys, set `allow_duplicate_keys` to True",
+                "Some of the duplicates:",
+                column_to_list(
+                    df.filter((col(key_col_name).is_duplicated())), key_col_name
+                )[:3],
+            )
     df = df.to_dicts()
     return {row[key_col_name]: row[value_col_name] for row in df}

--- a/tests/test_dataframe_helper.py
+++ b/tests/test_dataframe_helper.py
@@ -2,6 +2,8 @@ from harley import column_to_list
 import pytest
 from datetime import datetime
 from tests.conftest import polars_frames
+from harley.dataframe_helper import two_columns_to_dictionary
+from polars import DataFrame
 
 floats=[4.0, 5.0, 6.0, 7.0, 8.0]
 data = {
@@ -23,3 +25,23 @@ def test_column_to_list(frame_type:str):
     exp = floats
     res = column_to_list(frame, "float")
     assert exp==res
+
+
+def test_two_columns_to_dictionary_passes():
+    inp_col_key_vals = [i for i in range(9)]
+    inp_col_key="inp_col_key"
+    inp_col_val_vals = [i for i in range(1, 10)]
+    inp_col_val="inp_col_val"
+    df = DataFrame({inp_col_key:inp_col_key_vals, inp_col_val:inp_col_val_vals})
+    exp = dict(zip(inp_col_key_vals, inp_col_val_vals))
+    res = two_columns_to_dictionary(df = df, key_col_name=inp_col_key, value_col_name=inp_col_val)
+    assert res==exp
+
+def test_two_columns_to_dictionary_raises_error_on_nested_keys():
+    inp_col_key_vals = [[123],[234]]
+    inp_col_key="inp_col_key"
+    inp_col_val_vals = [i for i in range( 2)]
+    inp_col_val="inp_col_val"
+    df = DataFrame({inp_col_key:inp_col_key_vals, inp_col_val:inp_col_val_vals})
+    with pytest.raises(ValueError):
+        two_columns_to_dictionary(df = df, key_col_name=inp_col_key, value_col_name=inp_col_val)

--- a/tests/test_dataframe_helper.py
+++ b/tests/test_dataframe_helper.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from tests.conftest import polars_frames
 from harley.dataframe_helper import two_columns_to_dictionary
 from polars import DataFrame
+from polars.testing import assert_frame_equal
 
 floats=[4.0, 5.0, 6.0, 7.0, 8.0]
 data = {
@@ -45,3 +46,20 @@ def test_two_columns_to_dictionary_raises_error_on_nested_keys():
     df = DataFrame({inp_col_key:inp_col_key_vals, inp_col_val:inp_col_val_vals})
     with pytest.raises(ValueError):
         two_columns_to_dictionary(df = df, key_col_name=inp_col_key, value_col_name=inp_col_val)
+
+@pytest.fixture()
+def duplicate_keys_df() -> DataFrame:
+    inp_col_key_vals = ["duplicate","duplicate", "not duplicate"]
+    inp_col_key="inp_col_key"
+    inp_col_val_vals = [i for i in range(3)]
+    inp_col_val="inp_col_val"
+    return DataFrame({inp_col_key:inp_col_key_vals, inp_col_val:inp_col_val_vals})
+
+def test_two_columns_to_dictionary_raises_error_on_duplicate_keys_by_default(duplicate_keys_df: DataFrame):
+    with pytest.raises(ValueError):
+        two_columns_to_dictionary(df= duplicate_keys_df, key_col_name="inp_col_key", value_col_name="inp_col_val", allow_duplicates_keys=False)
+
+def test_two_columns_to_dictionary_allows_duplicate_keys(duplicate_keys_df: DataFrame):
+    exp = {"duplicate":1, "not duplicate":2}
+    res= two_columns_to_dictionary(df= duplicate_keys_df, key_col_name="inp_col_key", value_col_name="inp_col_val", allow_duplicates_keys=True)
+    assert res == exp


### PR DESCRIPTION
* Implement two columns to dictionary
* Pure python - rust _could_ be more performant but:

- This is always going to a python object anyway, I think it would always be locked by the gil in some way
- It was going to need to handle all the different types in different ways (but reject some of the polars dtypes) and possibly require figuring out how to use a generic, which hardly seemed worth it for a function which is usually not a great idea to use anyway (goes back into python/the GIL whereas you often see this type of thing being used where a join would be better, or where a DataFrame is being used in a transaction-like way).