### PR TITLE
Feature/flatten struct, but with BFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 target
 .venv/*
+.benchmark

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.so
 *.pyc
 target

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All functions, whether they should be implemented.
 * [x] `is_truthy` - rust.
 * [x] `is_false` - rust.
 * [x] `is_true` - rust.
-* `is_null_or_blank` DONE - rust.
+* [x] `is_null_or_blank` - rust.
 * `is_not_in` - might be covered by native polars.
 * [x] `null_between` - rust.
 
@@ -56,7 +56,6 @@ Wouldn't even make a very good log parser.
 
 ### Schema Helpers
 * [ ] `print_schema_as_code` - python.
-
 * `schema_from_csv` - python. Will not implement: should not be assigning schema with a csv. I have seen all sorts of nightmarish 'mapping'/'schema' files at work and I have seen enough to be convinced it is bad practice. code == code.
 * [x] `complex_fields` - python.
 
@@ -66,9 +65,9 @@ Wouldn't even make a very good log parser.
 ### Transformations
 * `with_columns_renamed` - covered by `polars.DataFrame|LazyFrame.rename` in polars.
 * `with_some_columns_renamed` see `with_columns_renamed`.
-* `snake_case_col_names` python. DONE. Needs more robust tests than `quinn`.
+* [x] `snake_case_col_names` python. Needs more robust tests than `quinn`.
 * `sort_columns` I think this is covered by polars sort?
-* [*] `flatten_struct` python.
+* [x] `flatten_struct` python.
 * `flatten_map` There is no `map` type in polars.
 * `flatten_dataframe` Could possibly not implement, I don't think this handles things like deeply nested structs; less robust than it sounds. Nested structs exist in pyspark but I'm not sure in polars...
 

--- a/harley/string_functions.py
+++ b/harley/string_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 import polars as pl
 
@@ -55,6 +55,7 @@ def remove_non_word_characters(expr: IntoExpr) -> IntoExpr:
         is_elementwise=True,
         lib=lib,
     )
+
 
 def anti_trim(expr: List[IntoExpr]) -> IntoExpr:
     """

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -11,6 +11,9 @@ def snake_case_column_names(df: PolarsFrame) -> PolarsFrame:
     return df.rename(new_col_names)
 
 
+class ColumnNameRepeatedError(ValueError):
+    """raised when a column name would be repeated after flatten_struct"""
+
 def flatten_struct(
     df: PolarsFrame,
     struct_columns: Union[str, List[str]],
@@ -23,20 +26,24 @@ def flatten_struct(
         struct_columns = [struct_columns]
     if not recursive:
         limit = 1
-    if not isinstance(limit, int) and limit is not None:
+    if limit is not None and not isinstance(limit, int):
         raise ValueError("limit must be a positive integer or None")
     if limit is not None and limit < 0:
         raise ValueError("limit must be a positive integer or None")
     if limit == 0:
         logging.warning("limit of 0 will result in no transformations")
         return df
-    if not isinstance(ldf := df, LazyFrame):
-        ldf = ldf.lazy()
-
+    ldf = df.lazy() # noop if df is LazyFrame
+    all_column_names = ldf.collect_schema().names()
+    if any(separator in (witness := column) for column in all_column_names):
+        logging.warning(
+            f"separator \"{separator}\" found in column names, e.g. \"{witness}\". "
+            "This might columns to be repeated this flatten_struct function to error"
+        )
     non_struct_columns = list(set(ldf.collect_schema().names()) - set(struct_columns))
     struct_schema = ldf.select(*struct_columns).collect_schema()
     col_dtype_expr_names = [(struct_schema[c], col(c), c) for c in struct_columns]
-    result_names: Dict[Tuple[int, str], Expr] = {}
+    result_names: Dict[str, Expr] = {}
     level = 0
     while (limit is None and col_dtype_expr_names) or (limit is not None and level < limit):
         level += 1
@@ -44,7 +51,11 @@ def flatten_struct(
         for dtype, col_expr, name in col_dtype_expr_names:
             if not isinstance(dtype, Struct):
                 if drop_original_struct:
-                    result_names[(level, name)] = col_expr
+                    if name in result_names:
+                        raise ColumnNameRepeatedError(
+                            f"Column name {name} would be repeated after flatten_struct"
+                        )
+                    result_names[name] = col_expr
                 continue
             new_col_dtype_exprs += [
                 (
@@ -63,52 +74,14 @@ def flatten_struct(
                 )
         col_dtype_expr_names = new_col_dtype_exprs
     if level == limit and col_dtype_expr_names:
-        for dtype, col_expr, name in col_dtype_expr_names:
-            result_names[(level, name)] = col_expr
+        for _, col_expr, name in col_dtype_expr_names:
+            result_names[name] = col_expr
     if result_names and drop_original_struct:
         ldf = ldf.select(
             [col(c) for c in non_struct_columns] +
-            [col_expr.alias(name) for (_, name), col_expr in result_names.items()]
+            [col_expr.alias(name) for name, col_expr in result_names.items()]
         )
 
     if isinstance(df, LazyFrame):
         return ldf
     return ldf.collect()
-
-
-"""
-    struct_schema = df.select(*struct_columns).schema
-    unnested_columns = []
-    new_col_names = []
-    for struct_col in struct_columns:
-        nested_columns = struct_schema[struct_col]
-        unnested_columns += [
-            col(struct_col)
-            .struct.field(field)
-            .alias(separator.join([struct_col, field]))
-            for field, _ in nested_columns
-        ]
-        if recursive:
-            new_col_names += [
-                separator.join([struct_col, field]) for field, _ in nested_columns
-            ]
-    df = df.with_columns(unnested_columns)
-    if drop_original_struct:
-        df = df.drop(struct_columns)
-    if recursive and not limit == 0:
-        # empty list is Falsey
-        if (new_unnested_columns := [
-            col
-            for col, dtype in df.select(new_col_names).schema.items()
-            if isinstance(dtype, Struct)
-        ]):
-            df = flatten_struct(
-                df=df,
-                struct_columns=new_unnested_columns,
-                separator=separator,
-                drop_original_struct=drop_original_struct,
-                recursive=True,
-                limit=(limit - 1 if limit else None),
-            )
-    return df
-"""

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -5,6 +5,7 @@ from polars import col, Struct, Expr, LazyFrame
 
 import warnings
 
+
 def snake_case_column_names(df: PolarsFrame) -> PolarsFrame:
     new_col_names = columns_to_snake_case(df.columns)
     return df.rename(new_col_names)

--- a/harley/transformations.py
+++ b/harley/transformations.py
@@ -1,7 +1,9 @@
 from harley.utils import PolarsFrame
 from .harley import columns_to_snake_case
-from typing import Union, List
-from polars import col, Struct
+from typing import Union, List, Dict
+from polars import col, Struct, Expr, LazyFrame
+
+import logging
 
 
 def snake_case_column_names(df: PolarsFrame) -> PolarsFrame:
@@ -19,6 +21,62 @@ def flatten_struct(
 ) -> PolarsFrame:
     if isinstance(struct_columns, str):
         struct_columns = [struct_columns]
+    if not recursive:
+        limit = 1
+    if not isinstance(limit, int) and limit is not None:
+        raise ValueError("limit must be a positive integer or None")
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be a positive integer or None")
+    if limit == 0:
+        logging.warning("limit of 0 will result in no transformations")
+        return df
+    if not isinstance(ldf := df, LazyFrame):
+        ldf = ldf.lazy()
+
+    non_struct_columns = list(set(ldf.collect_schema().names()) - set(struct_columns))
+    struct_schema = ldf.select(*struct_columns).collect_schema()
+    col_dtype_expr_names = [(struct_schema[c], col(c), c) for c in struct_columns]
+    result_names: Dict[Tuple[int, str], Expr] = {}
+    level = 0
+    while (limit is None and col_dtype_expr_names) or (limit is not None and level < limit):
+        level += 1
+        new_col_dtype_exprs = []
+        for dtype, col_expr, name in col_dtype_expr_names:
+            if not isinstance(dtype, Struct):
+                if drop_original_struct:
+                    result_names[(level, name)] = col_expr
+                continue
+            new_col_dtype_exprs += [
+                (
+                    field.dtype,
+                    col_expr.struct.field(field.name),
+                    name + separator + field.name,
+                )
+                for field in dtype.fields
+            ]
+            if not drop_original_struct:
+                ldf = ldf.with_columns(
+                    col_expr.struct.field(field.name).alias(
+                        name + separator + field.name
+                    )
+                    for field in dtype.fields
+                )
+        col_dtype_expr_names = new_col_dtype_exprs
+    if level == limit and col_dtype_expr_names:
+        for dtype, col_expr, name in col_dtype_expr_names:
+            result_names[(level, name)] = col_expr
+    if result_names and drop_original_struct:
+        ldf = ldf.select(
+            [col(c) for c in non_struct_columns] +
+            [col_expr.alias(name) for (_, name), col_expr in result_names.items()]
+        )
+
+    if isinstance(df, LazyFrame):
+        return ldf
+    return ldf.collect()
+
+
+"""
     struct_schema = df.select(*struct_columns).schema
     unnested_columns = []
     new_col_names = []
@@ -53,3 +111,4 @@ def flatten_struct(
                 limit=(limit - 1 if limit else None),
             )
     return df
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ maturin
 ruff
 pytest
 mypy
+pytest-timeout

--- a/tests/test_booleans.py
+++ b/tests/test_booleans.py
@@ -6,7 +6,6 @@ from polars.testing import assert_frame_equal
 from typing import List, Callable, Union
 
 
-
 @pytest.mark.parametrize("frame_type", polars_frames)
 @pytest.mark.parametrize(
     "inp, exp, all_white_space_as_null",

--- a/tests/test_column_functions.py
+++ b/tests/test_column_functions.py
@@ -1,11 +1,12 @@
 from harley.column_functions import null_between
 from harley.utils import polars_frames
 import pytest
-from polars import DataFrame, LazyFrame
+from polars import DataFrame, LazyFrame, DataType
 from polars.testing import assert_frame_equal
-from typing import Tuple, Any, Union
+from typing import Tuple, Any, Union, List
 from harley.column_functions import multi_equals
 from harley.column_functions import approx_equal
+
 
 @pytest.mark.parametrize("frame_type", polars_frames)
 @pytest.mark.parametrize(
@@ -26,7 +27,7 @@ from harley.column_functions import approx_equal
             [True, False, True, False],
             4.1,
         ),
-            (
+        (
             [[12, 20, 44, 32], [14, 26, 43, 9]],
             [False, False, True, False],
             1.9,
@@ -41,8 +42,13 @@ def test_approx_equal(
 ):
     schema = ["left", "right"]
     data = frame_type(dict(zip(schema, inp)))
-    exp = DataFrame({"res":exp})
-    if isinstance(res := data.select(res = approx_equal(col_1 ="left", col_2="right", threshold=thresh)), LazyFrame):
+    exp = DataFrame({"res": exp})
+    if isinstance(
+        res := data.select(
+            res=approx_equal(col_1="left", col_2="right", threshold=thresh)
+        ),
+        LazyFrame,
+    ):
         res = res.collect()
     assert_frame_equal(res, exp)
 

--- a/tests/test_maths.py
+++ b/tests/test_maths.py
@@ -6,7 +6,6 @@ from polars.testing import assert_frame_equal
 from typing import List, Dict, Any, Union
 
 
-
 @pytest.mark.parametrize("frame_type", polars_frames)
 @pytest.mark.parametrize(
     "data, exp",

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -63,6 +63,7 @@ def test_remove_non_space_characters(lazy: bool):
         frame = frame.collect()
     assert_series_equal(frame["actual"], frame["expected"], check_names=False)
 
+
 @pytest.mark.parametrize("lazy", [True, False])
 def test_anti_trim(lazy: bool):
     string_data = [

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -176,7 +176,7 @@ def test_flatten_struct_recursive_limit(
         ]
     )
     if isinstance(
-        res := flatten_struct(df=inp, struct_columns="coords", recursive=True, limit=1),
+        res := flatten_struct(df=inp, struct_columns="coords", recursive=True, limit=2),
         LazyFrame,
     ):
         res = res.collect()

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -72,6 +72,7 @@ def data_with_struct() -> List[Series]:
 
 
 @pytest.mark.parametrize("frame_type", polars_frames)
+@pytest.mark.timeout(1)
 def test_flatten_struct(frame_type: DataType, data_with_struct: List[Series]):
     inp = frame_type(data_with_struct)
     exp = DataFrame(
@@ -88,6 +89,7 @@ def test_flatten_struct(frame_type: DataType, data_with_struct: List[Series]):
 
 
 @pytest.mark.parametrize("frame_type", polars_frames)
+@pytest.mark.timeout(1)
 def test_flatten_struct_do_not_drop(
     frame_type: DataType, data_with_struct: List[Series]
 ):
@@ -113,6 +115,7 @@ def test_flatten_struct_do_not_drop(
 
 
 @pytest.mark.parametrize("frame_type", polars_frames)
+@pytest.mark.timeout(1)
 def test_flatten_struct_separator(frame_type: DataType, data_with_struct: List[Series]):
     inp = frame_type(data_with_struct)
     exp = DataFrame(
@@ -142,6 +145,7 @@ def nested_struct_data() -> dict:
 
 
 @pytest.mark.parametrize("frame_type", polars_frames)
+@pytest.mark.timeout(1)
 def test_flatten_struct_recursive(
     frame_type: DataType, nested_struct_data: List[Series]
 ):
@@ -163,6 +167,7 @@ def test_flatten_struct_recursive(
 
 
 @pytest.mark.parametrize("frame_type", polars_frames)
+@pytest.mark.timeout(1)
 def test_flatten_struct_recursive_limit(
     frame_type: DataType, nested_struct_data: List[Series]
 ):

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -109,7 +109,9 @@ def test_flatten_struct_do_not_drop(
             ),
         ]
     )
-    if isinstance(res := flatten_struct(inp, "ratings", drop_original_struct=False), LazyFrame):
+    if isinstance(
+        res := flatten_struct(inp, "ratings", drop_original_struct=False), LazyFrame
+    ):
         res = res.collect()
     assert_frame_equal(res, exp, check_column_order=False)
 


### PR DESCRIPTION
- refactor flatten_struct to perform the recursion using Breadth First Search instead of recursive calls
- add errors if it catches it would create the same column multiple times (e.g. `"a:b" : "c"` vs `"a" : "b" : "c"`), or create a column that's already in the dataframe itself. This is usualy because one or more of the fields / columns has the separator in its name.
- update tests
  - add tests for errors
  - also added pytest-timeout to requirements, though it's just dev-only. Useful for when I was refactoring and accidentally introduced infinite loops. Now it times out if the test doesn't finish in a fixed time (e.g. 1 second)

Using this benchmark, I found it could be twice as fast! (It was already very fast in the first place. Also 1000 runs might be a bit small.)
```text
# OLD
Generating dataframe
Done
Testing flatten_struct with recursive=True
for 1000000 rows for 1000 runs
It took 0.001018240371000502s on average
Testing flatten_struct with recursive=True, drop_original_struct=False
for 1000000 rows for 1000 runs
It took 0.0009654799259988067s on average
# NEW
Generating dataframe
Done
Testing flatten_struct with recursive=True
for 1000000 rows for 1000 runs
It took 0.0004731835689999571s on average
Testing flatten_struct with recursive=True, drop_original_struct=False
for 1000000 rows for 1000 runs
It took 0.0006911943859995518s on average
```
<details>
<summary>Benchmarking code</summary>

```python
import timeit
import polars as pl
from harley import flatten_struct

DATAFRAME_LENGTH = 1_000_000

def gen_dataframe(n: int) -> pl.DataFrame:
    print("Generating dataframe")
    rows = [
        {
            "a": {"b": {"c": x, "d": 2 * x}, "e": {"f": 3 * x, "g": 4 * x}},
            "p": {"q": True, "r": "bar", "s": 5.0 * x},
            "t": {"u": {"v": {"w": f"{x}"}}},
        }
        for x in range(n)
    ]
    df = pl.DataFrame(rows)
    print("Done")
    return df

df = gen_dataframe(DATAFRAME_LENGTH)
setup = "from __main__ import df, flatten_struct"
stmt = "res_df = flatten_struct(df, ['a', 'p', 't'], recursive=True)"

REPEAT_TIMES = 1000
print("Testing flatten_struct with recursive=True")
print(f"for {DATAFRAME_LENGTH} rows for {REPEAT_TIMES} runs")
t = timeit.timeit(setup=setup, stmt=stmt, number=REPEAT_TIMES)
print(f"It took {t/REPEAT_TIMES}s on average")

stmt = "res_df = flatten_struct(df, ['a', 'p', 't'], recursive=True, drop_original_struct=False)"
print("Testing flatten_struct with recursive=True, drop_original_struct=False")
print(f"for {DATAFRAME_LENGTH} rows for {REPEAT_TIMES} runs")
t = timeit.timeit(setup=setup, stmt=stmt, number=REPEAT_TIMES)
print(f"It took {t/REPEAT_TIMES}s on average")
```
</details>